### PR TITLE
Change CashuControler auth policy

### DIFF
--- a/Plugin/BTCPayServer.Plugins.Cashu/Controllers/CashuControler.cs
+++ b/Plugin/BTCPayServer.Plugins.Cashu/Controllers/CashuControler.cs
@@ -30,7 +30,7 @@ using StoreData = BTCPayServer.Data.StoreData;
 namespace BTCPayServer.Plugins.Cashu.Controllers;
 
 [Route("stores/{storeId}/cashu")]
-[Authorize(Policy = Policies.CanModifyServerSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
+[Authorize(Policy = Policies.CanModifyStoreSettings, AuthenticationSchemes = AuthenticationSchemes.Cookie)]
 public class CashuController: Controller
 {
     public CashuController(InvoiceRepository invoiceRepository,


### PR DESCRIPTION
Fixes: #4 - now CashuController policy allows store owners to modify cashu settings and use cashu wallet. 